### PR TITLE
fix json example, missed comma

### DIFF
--- a/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
@@ -389,7 +389,7 @@ Properties without a default value are required.
     "attributes": {
       "name": "my-module",
       "provider": "aws",
-      "registry-name": "private"
+      "registry-name": "private",
       "no-code": true
     }
   }
@@ -406,7 +406,7 @@ Properties without a default value are required.
       "name": "vpc",
       "namespace": "terraform-aws-modules",
       "provider": "aws",
-      "registry-name": "public"
+      "registry-name": "public",
       "no-code": true
     }
   }


### PR DESCRIPTION
### What
example json is missing comma, being invalid json
`cloud-docs/api-docs/private-registry/modules#sample-request-3`

### Why
N/A

### Screenshots
<img width="1006" alt="Screenshot 2022-11-03 at 13 51 30" src="https://user-images.githubusercontent.com/1255709/199725364-00ba63d3-a2fd-4731-a5ef-83c0413d6aa9.png">


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
